### PR TITLE
Fix incorrect type name for nested NonNulls and Lists

### DIFF
--- a/index.js
+++ b/index.js
@@ -240,7 +240,7 @@ function diffFields(thisType, otherType, options) {
             }
             const thisTypeName = getFieldTypeName(thisField);
             const otherTypeName = getFieldTypeName(otherField);
-            if (thisField.type.name !== otherField.type.name) {
+            if (thisTypeName !== otherTypeName) {
                 const description = format('Field type changed on field {0}.{1} from : `"{2}"` to `"{3}"`.', thisType, thisField.name, thisTypeName, otherTypeName);
                 diffs.push(new GraphQLDiff(thisType, otherType, DiffType.FieldDiff, description, false));
             }
@@ -384,12 +384,16 @@ function getArgumentMap(fieldArguments) {
  * @returns {String} field name
  */
 function getFieldTypeName(field) {
-    if (field.type instanceof GraphQLNonNull) {
-        return field.type.ofType.name + "!";
-    } else if (field.type instanceof GraphQLList) {
-        return "[" + field.type.ofType.name + "]";
+    return buildTypeString(field.type)
+}
+
+function buildTypeString(type) {
+    if (type instanceof GraphQLNonNull) {
+        return buildTypeString(type.ofType) + "!";
+    } else if (type instanceof GraphQLList) {
+        return "[" + buildTypeString(type.ofType) + "]";
     } else {
-        return field.type.name;
+        return type.name;
     }
 }
 

--- a/test/index.js
+++ b/test/index.js
@@ -577,6 +577,38 @@ describe('GraphQLSchema', function () {
             done();
         });
 
+        it('reports diff for different field types when nested GraphQLNonNull and GraphQLList', function (done) {
+            const schema1 =
+                'type Query {\n' +
+                '    myTags: Tag!\n' +
+                '}\n' +
+                'type Tag {\n' +
+                '    notNullString: String!\n' +
+                '    listNotNullString: [String!]\n' +
+                '    notNullListNotNullString: [String!]!\n' +
+                '    listNotNullListNotNullString: [[String!]!]\n' +
+                '}';
+
+            const schema2 =
+                'type Query {\n' +
+                '    myTags: Tag!\n' +
+                '}\n' +
+                'type Tag {\n' +
+                '    notNullString: String\n' +
+                '    listNotNullString: String!\n' +
+                '    notNullListNotNullString: [String!]\n' +
+                '    listNotNullListNotNullString: [String!]!\n' +
+                '}';
+            const a = buildSchema(schema1);
+            const b = buildSchema(schema2);
+            const diffs = a.diff(b);
+            assert(diffExists(diffs, new GraphQLDiff(a, b, DiffType.FieldDiff, 'Field type changed on field Tag.notNullString from : `"String!"` to `"String"`.', false)));
+            assert(diffExists(diffs, new GraphQLDiff(a, b, DiffType.FieldDiff, 'Field type changed on field Tag.listNotNullString from : `"[String!]"` to `"String!"`.', false)));
+            assert(diffExists(diffs, new GraphQLDiff(a, b, DiffType.FieldDiff, 'Field type changed on field Tag.notNullListNotNullString from : `"[String!]!"` to `"[String!]"`.', false)));
+            assert(diffExists(diffs, new GraphQLDiff(a, b, DiffType.FieldDiff, 'Field type changed on field Tag.listNotNullListNotNullString from : `"[[String!]!]"` to `"[String!]!"`.', false)));
+            done();
+        });
+
         function diffExists(diffs, expectedDiff) {
             for (let i = 0; i < diffs.length; i++) {
                 if (diffs[i].diffType === expectedDiff.diffType && diffs[i].description === expectedDiff.description) {


### PR DESCRIPTION
Comparing field types works incorrectly for more complicated cases like "[String!]!"
with nested GraphQLNonNull and GraphQLList types.
Bug occurs because field.type.ofType.name is empty for GraphQLNonNull or GraphQLList.
Provided fix with specs.
