### PR TITLE
Don't install npm as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,8 +21,7 @@
   },
   "homepage": "https://github.com/jarwol/graphql-schema-utils#readme",
   "dependencies": {
-    "lodash.clonedeep": "^4.5.0",
-    "npm": "^6.4.1"
+    "lodash.clonedeep": "^4.5.0"
   },
   "peerDependencies": {
     "graphql": "^0.8.2"


### PR DESCRIPTION
You don't `require('npm')` anywhere, so you shouldn't need to install npm as a dependency. You might have meant to put it in the `"engines"` field in package.json, but I expect this package will install fine with yarn also?